### PR TITLE
feat: UTH-25 - add typeCode to ApartmentInfo

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -305,6 +305,7 @@ interface ApartmentInfo {
   code: string
   number: string
   type: string
+  typeCode: string
   entrance: string
   floor: string
   hasElevator: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,7 +305,7 @@ interface ApartmentInfo {
   code: string
   number: string
   type: string
-  typeCode: string
+  roomTypeCode: string
   entrance: string
   floor: string
   hasElevator: boolean


### PR DESCRIPTION
typeCode is a code representation of the type of apartment (1ROK, 2ROK) etc.