### PR TITLE
Feat: UTH-212 Parking Spaces for Secret Identities

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -246,8 +246,8 @@ interface Listing {
 
 interface Applicant {
   id: number
-  name: string
-  nationalRegistrationNumber: string
+  name?: string | undefined
+  nationalRegistrationNumber?: string | undefined
   contactCode: string
   applicationDate: Date
   applicationType?: string | undefined //todo: "Additional" or "Replace". Should be an enum in the future


### PR DESCRIPTION
A contact with secret identity should be able to rent an internal parking space. A contact with a secret identity doesn't have name or national security number set

* Name and National Security Number can be null for Applicant