### PR TITLE
feat: MIM-492: visa arenden for lagenhet i property tree

### DIFF
--- a/src/work-order/index.ts
+++ b/src/work-order/index.ts
@@ -16,9 +16,9 @@ interface WorkOrder {
   Status: string
   UseMasterKey: boolean
   WorkOrderRows: {
-    Description: string
-    LocationCode: string
-    EquipmentCode: string
+    Description: string | null
+    LocationCode: string | null
+    EquipmentCode: string | null
   }[]
   Messages?: WorkOrderMessage[]
 }

--- a/src/work-order/index.ts
+++ b/src/work-order/index.ts
@@ -21,6 +21,7 @@ interface WorkOrder {
     EquipmentCode: string | null
   }[]
   Messages?: WorkOrderMessage[]
+  Url?: string
 }
 
 interface WorkOrderMessage {


### PR DESCRIPTION
Lägger till `Url` på `WorkOrder` som kan innehålla en djuplänk till ärendet i Odoo.

Extra: `Description`, `LocationCode` och `EquipmentCode` blir `false` om de inte fylls i när ett ärende skapas, vilket orsakar valideringsfel i core. Om de inte finns sätts de till `null` i https://github.com/Bostads-AB-Mimer/onecore-work-order/pull/17.